### PR TITLE
This PR fixes a build bug with LLD9 and updates stm32l0xx-hal cargo dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
  "panic-halt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic-semihosting 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stm32l0 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "stm32l0xx-hal 0.1.7",
+ "stm32l0xx-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sx1276 0.1.3 (git+https://github.com/lthiery/sx1276-rs.git?branch=working-code)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -535,8 +535,10 @@ dependencies = [
 
 [[package]]
 name = "stm32l0xx-hal"
-version = "0.1.7"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortex-m 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortex-m-rt 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -745,6 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stm32l0 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8e831bba8dd787feae7b190dece185346e5d10c271589205d33cb9beee75f38f"
+"checksum stm32l0xx-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64240b26191d0be840519c5454ee5773c41c7569e58bc9cff969bb259ce868c1"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum sx1276 0.1.3 (git+https://github.com/lthiery/sx1276-rs.git?branch=working-code)" = "<none>"
 "checksum sx1276-sys 0.1.0 (git+https://github.com/lthiery/sx1276-rs.git?branch=working-code)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cast = { version = "0.2.2", default-features = false }
 nb = "0.1.2"
 panic-halt = "0.2.0"
 enum_primitive = {version = "*", git = "https://github.com/lthiery/enum_primitive-rs.git" }
-
+stm32l0xx-hal = {version = "0.2.0", features = ["stm32l0x2", "rt"]}
 
 [dependencies.stm32l0]
 version = "0.7.0"
@@ -35,13 +35,6 @@ panic-semihosting = "0.5.1"
 version = "0.2"
 default-features = false
 
-
 [dependencies.sx1276]
 git                     = "https://github.com/lthiery/sx1276-rs.git"
 branch					= "working-code"
-
-
-[dependencies.stm32l0xx-hal]
-path = "../stm32l0xx-hal"
-features = ["stm32l0x2", "rt"]
-

--- a/link.x
+++ b/link.x
@@ -143,6 +143,7 @@ SECTIONS
   /DISCARD/ :
   {
     /* Unused exception related info that only wastes space */
+    *(.ARM.exidx);
     *(.ARM.exidx.*);
     *(.ARM.extab.*);
   }


### PR DESCRIPTION
**LLD9 Bug and Fix Issue**

- [Issue with fix](https://github.com/rust-embedded/cortex-m-rt/issues/197)

**stm32l0xx-hal dependency update**

- Replaced git repo dependency with crate version.


