### PR TITLE
Separated Accelerometer Interrupt Into Two Dedicated Pins

### DIFF
--- a/src/bma400.rs
+++ b/src/bma400.rs
@@ -70,9 +70,9 @@ impl Bma400 {
         // map gen1 to int1 pin
         self.write_addr(i2c, Register::Int1Map, 0x04)?;
         // map gen2 to int2 pin
-        self.write_addr(i2c, Register::Int2Map, 0x04)?;
-        // latching for both interrupts?
-        self.write_addr(i2c, Register::IntConf1, 0x80)?;
+        self.write_addr(i2c, Register::Int2Map, 0x08)?;
+        // non-latching for both interrupts
+        self.write_addr(i2c, Register::IntConf1, 0x00)?;
 
         // int1 and int2 pin interrupt active high
         self.write_addr(i2c, Register::Int12IoCtrl, 0x22)?;
@@ -84,30 +84,26 @@ impl Bma400 {
         // int2
         self.write_addr(i2c, Register::Gen2IntConfig0, 0xFA)?;
 
-        // or all the things, inactivity triggers
-        // match int_type {
-        //     Activity => self.write_addr(i2c, Register::Gen1IntConfig1, 0x01)?,
-        //     Inactivity => self.write_addr(i2c, Register::Gen1IntConfig1, 0x00)?,
-        // }
-
         // Activity on int1
-        self.write_addr(i2c, Register::Gen1IntConfig1, 0x01)?;
+        self.write_addr(i2c, Register::Gen1IntConfig1, 0x02)?;
         // Inactivity on int2
         self.write_addr(i2c, Register::Gen2IntConfig1, 0x00)?;
 
         // threshold is 8mb/lsb
         // int1
-        self.write_addr(i2c, Register::Gen1IntConfig2, 0x01)?; // This might be too sensitive
+        self.write_addr(i2c, Register::Gen1IntConfig2, 0x01)?;
         // int2
         self.write_addr(i2c, Register::Gen2IntConfig2, 0x01)?;
 
         // set min duration
         // int1
-        self.write_addr(i2c, Register::Gen1IntConfig3, (delay >> 8) as u8)?;
-        self.write_addr(i2c, Register::Gen1IntConfig31, delay as u8)?;
+        let delay1 = 15;
+        self.write_addr(i2c, Register::Gen1IntConfig3, (delay1 >> 8) as u8)?;
+        self.write_addr(i2c, Register::Gen1IntConfig31, delay1 as u8)?;
         // int2
-        self.write_addr(i2c, Register::Gen2IntConfig3, (delay >> 8) as u8)?;
-        self.write_addr(i2c, Register::Gen2IntConfig31, delay as u8)?;       
+        let delay2 = 4800 * 5;
+        self.write_addr(i2c, Register::Gen2IntConfig3, (delay2 >> 8) as u8)?;
+        self.write_addr(i2c, Register::Gen2IntConfig31, delay2 as u8)?;
 
         // enable gen1 and gen2 interrupt in normal mode
         self.write_addr(i2c, Register::IntConf0, 0xC)?;

--- a/src/bma400.rs
+++ b/src/bma400.rs
@@ -9,9 +9,6 @@ pub enum IntType {
     Inactivity,
 }
 
-const ACTIVITY_DURATION: u16 = 15;
-const INACTIVITY_DURATION: u16 = 24000; //4 min
-
 impl Bma400 {
     pub fn new(sdo_position: bool) -> Bma400 {
         Bma400 {
@@ -61,7 +58,12 @@ impl Bma400 {
         self.read_addr(i2c, Register::IntStat0)
     }
 
-    pub fn configure_interrupt<I2C>(&self, i2c: &mut I2C) -> Result<(), <I2C as Write>::Error>
+    pub fn configure_interrupt<I2C>(
+        &self,
+        i2c: &mut I2C,
+        activity_duration: u16,
+        inactivity_duration: u16,
+    ) -> Result<(), <I2C as Write>::Error>
     where
         I2C: Write,
     {
@@ -98,16 +100,16 @@ impl Bma400 {
         self.write_addr(
             i2c,
             Register::Gen1IntConfig3,
-            (ACTIVITY_DURATION >> 8) as u8,
+            (activity_duration >> 8) as u8,
         )?;
-        self.write_addr(i2c, Register::Gen1IntConfig31, ACTIVITY_DURATION as u8)?;
+        self.write_addr(i2c, Register::Gen1IntConfig31, activity_duration as u8)?;
         // int2
         self.write_addr(
             i2c,
             Register::Gen2IntConfig3,
-            (INACTIVITY_DURATION >> 8) as u8,
+            (inactivity_duration >> 8) as u8,
         )?;
-        self.write_addr(i2c, Register::Gen2IntConfig31, INACTIVITY_DURATION as u8)?;
+        self.write_addr(i2c, Register::Gen2IntConfig31, inactivity_duration as u8)?;
 
         // enable gen1 and gen2 interrupt in normal mode
         self.write_addr(i2c, Register::IntConf0, 0xC)?;

--- a/src/bma400.rs
+++ b/src/bma400.rs
@@ -9,6 +9,9 @@ pub enum IntType {
     Inactivity,
 }
 
+const ACTIVITY_DURATION: u16 = 15;
+const INACTIVITY_DURATION: u16 = 24000; //4 min
+
 impl Bma400 {
     pub fn new(sdo_position: bool) -> Bma400 {
         Bma400 {
@@ -58,12 +61,7 @@ impl Bma400 {
         self.read_addr(i2c, Register::IntStat0)
     }
 
-    pub fn configure_interrupt<I2C>(
-        &self,
-        i2c: &mut I2C,
-        int_type: IntType,
-        delay: u16,
-    ) -> Result<(), <I2C as Write>::Error>
+    pub fn configure_interrupt<I2C>(&self, i2c: &mut I2C) -> Result<(), <I2C as Write>::Error>
     where
         I2C: Write,
     {
@@ -97,13 +95,19 @@ impl Bma400 {
 
         // set min duration
         // int1
-        let delay1 = 15;
-        self.write_addr(i2c, Register::Gen1IntConfig3, (delay1 >> 8) as u8)?;
-        self.write_addr(i2c, Register::Gen1IntConfig31, delay1 as u8)?;
+        self.write_addr(
+            i2c,
+            Register::Gen1IntConfig3,
+            (ACTIVITY_DURATION >> 8) as u8,
+        )?;
+        self.write_addr(i2c, Register::Gen1IntConfig31, ACTIVITY_DURATION as u8)?;
         // int2
-        let delay2 = 4800 * 5;
-        self.write_addr(i2c, Register::Gen2IntConfig3, (delay2 >> 8) as u8)?;
-        self.write_addr(i2c, Register::Gen2IntConfig31, delay2 as u8)?;
+        self.write_addr(
+            i2c,
+            Register::Gen2IntConfig3,
+            (INACTIVITY_DURATION >> 8) as u8,
+        )?;
+        self.write_addr(i2c, Register::Gen2IntConfig31, INACTIVITY_DURATION as u8)?;
 
         // enable gen1 and gen2 interrupt in normal mode
         self.write_addr(i2c, Register::IntConf0, 0xC)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,8 +52,8 @@ where
 }
 
 pub enum GpsEvent {
-    Activity,
-    Inactivity,
+    AccelActivity,
+    AccelInactivity,
     UserButton,
 }
 
@@ -303,7 +303,7 @@ const APP: () = {
         write!(resources.DEBUG_UART, "INT STAT: {}\r\n", int_status);
 
         match event {
-            GpsEvent::Activity => {
+            GpsEvent::AccelActivity => {
                 if !*ACTIVE {
                     write!(resources.DEBUG_UART, "Moving\r\n");
 
@@ -323,7 +323,7 @@ const APP: () = {
                     *ACTIVE = true;
                 }
             }
-            GpsEvent::Inactivity => {
+            GpsEvent::AccelInactivity => {
                 write!(resources.DEBUG_UART, "Idle\r\n");
                 resources.GPS_EN.set_low();
                 *ACTIVE = false;
@@ -443,7 +443,7 @@ const APP: () = {
         }
         if exti::line_is_triggered(reg, resources.BMA400_INT2.i) {
             resources.EXTI.clear_irq(resources.BMA400_INT2.i);
-            spawn.gps_event(GpsEvent::Inactivity);
+            spawn.gps_event(GpsEvent::AccelInactivity);
         }
     }
 
@@ -453,7 +453,7 @@ const APP: () = {
 
         if exti::line_is_triggered(reg, resources.BMA400_INT1.i) {
             resources.EXTI.clear_irq(resources.BMA400_INT1.i);
-            spawn.gps_event(GpsEvent::Activity);
+            spawn.gps_event(GpsEvent::AccelActivity);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,8 +52,8 @@ where
 }
 
 pub enum GpsEvent {
-    AccelInt1,
-    AccelInt2,
+    Activity,
+    Inactivity,
     UserButton,
 }
 
@@ -303,7 +303,7 @@ const APP: () = {
         write!(resources.DEBUG_UART, "INT STAT: {}\r\n", int_status);
 
         match event {
-            GpsEvent::AccelInt1 => {
+            GpsEvent::Activity => {
                 if !*ACTIVE {
                     write!(resources.DEBUG_UART, "Moving\r\n");
 
@@ -323,7 +323,7 @@ const APP: () = {
                     *ACTIVE = true;
                 }
             }
-            GpsEvent::AccelInt2 => {
+            GpsEvent::Inactivity => {
                 write!(resources.DEBUG_UART, "Idle\r\n");
                 resources.GPS_EN.set_low();
                 *ACTIVE = false;
@@ -443,7 +443,7 @@ const APP: () = {
         }
         if exti::line_is_triggered(reg, resources.BMA400_INT2.i) {
             resources.EXTI.clear_irq(resources.BMA400_INT2.i);
-            spawn.gps_event(GpsEvent::AccelInt2);
+            spawn.gps_event(GpsEvent::Inactivity);
         }
     }
 
@@ -453,7 +453,7 @@ const APP: () = {
 
         if exti::line_is_triggered(reg, resources.BMA400_INT1.i) {
             resources.EXTI.clear_irq(resources.BMA400_INT1.i);
-            spawn.gps_event(GpsEvent::AccelInt1);
+            spawn.gps_event(GpsEvent::Activity);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,7 @@ const APP: () = {
 
         // Wake and Config Accelerometer
         accel.wake(&mut i2c);
-        accel.configure_interrupt(&mut i2c, bma400::IntType::Inactivity, 4800 * 5);
+        accel.configure_interrupt(&mut i2c);
 
         let ubx = ubx::Ubx::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,7 @@ const APP: () = {
 
         // Wake and Config Accelerometer
         accel.wake(&mut i2c);
-        accel.configure_interrupt(&mut i2c);
+        accel.configure_interrupt(&mut i2c, 15, 24000);
 
         let ubx = ubx::Ubx::new();
 

--- a/src/ubx.rs
+++ b/src/ubx.rs
@@ -13,7 +13,12 @@ pub enum Message {
 #[derive(Copy, Clone)]
 pub enum Mode {
     HighPower,
-    LowPower
+    LowPower,
+}
+
+pub enum Power {
+    Enabled,
+    Disabled,
 }
 
 pub struct Ubx {
@@ -23,6 +28,7 @@ pub struct Ubx {
     pub payload_len: u16,
     pub count: u16,
     pub mode: Mode,
+    pub power: Power, 
 }
 
 enum_from_primitive! {
@@ -120,6 +126,7 @@ impl Ubx {
             payload_len: 0,
             count: 0,
             mode: Mode::HighPower,
+            power: Power::Disabled,
         }
     }
 


### PR DESCRIPTION
- Accelerator Activity and Inactivity Interrupt now have their own dedicated pins.
- Added active state to gps_event task to avoid repeated GPS enabling. 